### PR TITLE
Update CachedDeliveryAPI to access the 'fields' query param

### DIFF
--- a/src/util/CachedDeliveryApi.ts
+++ b/src/util/CachedDeliveryApi.ts
@@ -48,13 +48,14 @@ class CachedSearch {
     id: string,
     linkDepth = 0,
     versionStatus: VersionStatus = 'published',
-    project?: string
+    project?: string,
+    fields?: string[]
   ) {
     const client = Client.create({
       ...getClientConfig(project, this.ssr),
       versionStatus,
     });
-    return this.request(id, () => client.entries.get({ id, linkDepth }));
+    return this.request(id, () => client.entries.get({ id, linkDepth, fields }));
   }
 
   getContentType(id: string, project?: string) {


### PR DESCRIPTION
Backward compatible small update to the CachedDeliveryAPI Class. 

As a user of CRB we often will use the API class to do small API requests - however often it is better to set the fields on those to lower the payload. 

This PR simply adds the 'fields' query param which is already support in the client.entries class.